### PR TITLE
middleware内部ではreq.urlを利用しないとダメ

### DIFF
--- a/constants/api.ts
+++ b/constants/api.ts
@@ -33,7 +33,6 @@ export enum HttpCodes {
 }
 
 export const baseUrl = env?.NEXT_PUBLIC_BASE_URL ?? env?.VERCEL_URL ?? '';
-export const baseFullUrl = `https://${baseUrl}`;
 export const baseUrlHost = baseUrl.split(':')[0];
 const host = /http/.test(baseUrl) ? new URL(baseUrl).href : baseUrl;
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -6,7 +6,6 @@ import { checkPath } from '@/lib/check-path';
 import { isExpired } from '@/lib/date';
 import { debug } from '@/lib/log';
 import { getHeaders } from '@/lib/middleware-utils';
-import { baseFullUrl as requestUrl } from './constants/api';
 
 // proxy環境下でのredirect用
 export default withAuth(
@@ -18,7 +17,7 @@ export default withAuth(
     if (checkPath(req.nextUrl.pathname, accessAllowPages)) return NextResponse.next(responseInit);
 
     // redirect
-    if (req.nextUrl.pathname === '/') return NextResponse.redirect(new URL('/dashboard', requestUrl));
+    if (req.nextUrl.pathname === '/') return NextResponse.redirect(new URL('/dashboard', req.url));
 
     // token.expが切れていたらリダイレクト
     const token = await getToken({ req });
@@ -26,7 +25,7 @@ export default withAuth(
       let from = req.nextUrl.pathname;
       if (req.nextUrl.search) from += req.nextUrl.search;
 
-      return NextResponse.redirect(new URL(`${loginPage}?from=${encodeURIComponent(from)}`, requestUrl));
+      return NextResponse.redirect(new URL(`${loginPage}?from=${encodeURIComponent(from)}`, req.url));
     }
 
     return NextResponse.next(responseInit);


### PR DESCRIPTION
middleware内部ではreq.urlを利用しないとダメ

# 目的

middleware内部でredirect先がfatal出てるので、req.urlに差し替え

# やったこと

- middleware内部でredirect先がfatal出てるので、req.urlに差し替え